### PR TITLE
Add dynamic positional URL parameters

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -39,6 +39,8 @@ The following call-specific keyword arguments may be supplied:
 - `data`: form data, supplied in a dict format.
 - `body`: request body, supplied in a str format.
 
+- `pathvars`: a dict of named path variables.
+
 If the `parse` property is specified as `True` on the given endpoint, ergal will parse the response data accordingly (i.e. it will deserialize it if no targets are present, or return target values if they are).
 
 ### *async def* add_auth(method, **kwargs)

--- a/ergal/profile.py
+++ b/ergal/profile.py
@@ -96,6 +96,9 @@ class Profile:
         url = self.base + endpoint['path']
         targets = endpoint['targets'] if 'targets' in endpoint else None
 
+        if 'pathvars' in kwargs:
+            url = url.format(**kwargs['pathvars'])
+
         if 'auth' in endpoint and endpoint['auth']:
             if self.auth['method'] == 'headers':
                 kwargs['headers'] = {}
@@ -106,7 +109,7 @@ class Profile:
             elif self.auth['method'] == 'basic':
                 kwargs['auth'] = (self.auth['user'], self.auth['pass'])
 
-        for k in kwargs:
+        for k in list(kwargs):
             if k not in ('headers', 'params', 'data', 'body'):
                 kwargs.pop(k)
 
@@ -149,7 +152,10 @@ class Profile:
                     'method': method}
 
         for key in kwargs:
-            if key in ('headers', 'params', 'data', 'body', 'auth', 'parse', 'targets'):
+            if key in (
+                'headers', 'params', 'data', 'body',
+                'auth', 'parse', 'targets'):
+
                 endpoint[key] = kwargs[key]
 
         self.endpoints[name] = endpoint

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -65,18 +65,23 @@ class TestProfile:
 
         response = await profile.call('GET')
         assert type(response) is requests.models.Response
+        assert response.status_code == 200
 
         response = await profile.call('POST')
         assert type(response) is requests.models.Response
+        assert response.status_code == 200
 
         response = await profile.call('PUT')
         assert type(response) is requests.models.Response
+        assert response.status_code == 200
 
         response = await profile.call('PATCH')
         assert type(response) is requests.models.Response
+        assert response.status_code == 200
 
         response = await profile.call('DELETE')
         assert type(response) is requests.models.Response
+        assert response.status_code == 200
 
         data = await profile.call('JSON')
         assert type(data) is dict


### PR DESCRIPTION
Implements #11 

Now you can write an endpoint path with `{}` delimiters for parameterized values and supply the `pathvars` keyword argument at call with a dictionary of those named valued.

    >>> profile.add_endpoint('Example', '/example/{val1}/{val2}', 'GET')
    >>> profile.call('Example', pathvars={'val1': 'Hello', 'val2': 'World'})
    <Response [200]>